### PR TITLE
added option to provide exclusion patterns to the "compare folder" 

### DIFF
--- a/src/gphotos_sync/LocalFilesScan.py
+++ b/src/gphotos_sync/LocalFilesScan.py
@@ -17,7 +17,13 @@ class LocalFilesScan(object):
     Google Photos Library
     """
 
-    def __init__(self, root_folder: Path, scan_folder: Path, db: LocalData):
+    def __init__(
+        self,
+        root_folder: Path,
+        scan_folder: Path,
+        db: LocalData,
+        exclusion_pattern: list = [],
+    ):
         """
         Parameters:
             scan_folder: path to the root of local files to scan
@@ -25,6 +31,7 @@ class LocalFilesScan(object):
         """
         self._scan_folder: Path = scan_folder
         self._root_folder: Path = root_folder
+        self._exclusion_pattern: list = exclusion_pattern
         self._comparison_folder = self._root_folder / "comparison"
         self._ignore_files: str = str(root_folder / "*gphotos*")
         self._ignore_folders = [root_folder / path for path in IGNORE_FOLDERS]
@@ -55,7 +62,9 @@ class LocalFilesScan(object):
             for pth in folder.iterdir():
                 if pth.is_dir():
                     # IGNORE_FOLDERS for comparing against 'self'
-                    if pth not in self._ignore_folders:
+                    if pth not in self._ignore_folders and not any(
+                        pth.match(pattern) for pattern in self._exclusion_pattern
+                    ):
                         self.scan_folder(pth, index)
                 elif not pth.is_symlink():
                     if not pth.match(self._ignore_files):

--- a/src/gphotos_sync/__main__.py
+++ b/src/gphotos_sync/__main__.py
@@ -109,6 +109,14 @@ class GooglePhotosSyncMain:
         help="DEPRECATED: root of the local folders to compare to the Photos Library",
     )
     parser.add_argument(
+        "--exclusion-pattern",
+        action="store",
+        help="DEPRECATED: comma separated list of path exclusion patterns to consider"
+        " when running --compare-folder. Patterns can include match wildcards."
+        ' Ex: "*/@eaDir"',
+        default="",
+    )
+    parser.add_argument(
         "--favourites-only",
         action="store_true",
         help="only download media marked as favourite (star)",
@@ -410,6 +418,7 @@ class GooglePhotosSyncMain:
                 root_folder,
                 compare_folder,  # type: ignore
                 self.data_store,  # type: ignore
+                list(filter(None, args.exclusion_pattern.split(","))),  # type: ignore
             )
 
     def do_sync(self, args: Namespace):


### PR DESCRIPTION
this functionality is helpful for example in Synology NAS devices where Synology Photos folders (@eaDir) are created automatically at indexing.